### PR TITLE
Warning treated as validation errors. Non-empty ref XML elements reported as warnings.

### DIFF
--- a/Tools/Examples/Examples.csproj
+++ b/Tools/Examples/Examples.csproj
@@ -69,31 +69,31 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
     <Reference Include="Xbim.CobieExpress, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.CobieExpress.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.CobieExpress.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc.Extensions.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3.IO, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc2x3.IO.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc2x3.IO.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.IO.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.IO.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tools/Examples/packages.config
+++ b/Tools/Examples/packages.config
@@ -9,5 +9,5 @@
   <package id="SharpZipLib" version="0.86.0" targetFramework="net47" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net47" />
   <package id="System.IO.Packaging" version="4.0.0" targetFramework="net47" />
-  <package id="Xbim.Essentials" version="4.0.30-V035" targetFramework="net47" />
+  <package id="Xbim.Essentials" version="4.0.30-V036" targetFramework="net47" />
 </packages>

--- a/Tools/SchemaValidator/Logger.cs
+++ b/Tools/SchemaValidator/Logger.cs
@@ -77,12 +77,19 @@ namespace SchemaValidator
     {
         public ErrorAppender()
         {
-            Threshold = Level.Error;
+            Threshold = Level.Warn;
         }
-        public IEnumerable<Error> Errors => GetEvents().Select(e => new Error { Message = e.RenderedMessage, Exception = e.ExceptionObject });
+        public IEnumerable<LogMessage> Errors => GetEvents()
+            .Where(e => e.Level == Level.Error)
+            .Select(e => new LogMessage { Message = e.RenderedMessage, Exception = e.ExceptionObject });
+
+        public IEnumerable<LogMessage> Warnings => GetEvents()
+            .Where(e => e.Level == Level.Warn)
+            .Select(e => new LogMessage { Message = e.RenderedMessage, Exception = e.ExceptionObject });
+
     }
 
-    public struct Error
+    public struct LogMessage
     {
         public string Message;
         public Exception Exception;

--- a/Tools/SchemaValidator/Program.cs
+++ b/Tools/SchemaValidator/Program.cs
@@ -53,7 +53,7 @@ namespace SchemaValidator
                         Console.ForegroundColor = ConsoleColor.Red;
                     else
                         Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine($"Check finished. There are {validator.Errors.Count()} errors.");
+                    Console.WriteLine($"Check finished. There are {validator.Errors.Count()} errors and {validator.Warnings.Count()} warnings.");
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine($"Press any key to quit...");
                     Console.ReadKey();

--- a/Tools/SchemaValidator/SchemaValidator.csproj
+++ b/Tools/SchemaValidator/SchemaValidator.csproj
@@ -51,31 +51,31 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Xbim.CobieExpress, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.CobieExpress.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.CobieExpress.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc.Extensions.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3.IO, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc2x3.IO.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc2x3.IO.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.IO.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.IO.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=4.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Essentials.4.0.30-V035\lib\net40\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Essentials.4.0.30-V036\lib\net40\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tools/SchemaValidator/Validator.cs
+++ b/Tools/SchemaValidator/Validator.cs
@@ -19,7 +19,8 @@ namespace SchemaValidator
 {
     public class Validator
     {
-        public IEnumerable<Error> Errors => appender.Errors;
+        public IEnumerable<LogMessage> Errors => appender.Errors;
+        public IEnumerable<LogMessage> Warnings => appender.Warnings;
 
         private ILog log;
         private ErrorAppender appender;
@@ -415,7 +416,7 @@ namespace SchemaValidator
                 return false;
             }
 
-            return !Errors.Any();
+            return !Errors.Any() && !Warnings.Any();
         }
 
         private void LogEntityHistogram(IModel model)

--- a/Tools/SchemaValidator/packages.config
+++ b/Tools/SchemaValidator/packages.config
@@ -3,5 +3,5 @@
   <package id="log4net" version="2.0.8" targetFramework="net47" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net47" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net47" />
-  <package id="Xbim.Essentials" version="4.0.30-V035" targetFramework="net47" />
+  <package id="Xbim.Essentials" version="4.0.30-V036" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
Also, xBIM XML reader is made more error tolerant where in some cases it will log an error but will continue to parse the file instead of a complete failure.